### PR TITLE
Add some info to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ cd MyChiselProject
 The `--recursive`` option makes sure to check out all the submodules needed for this project.
 
 The next step is to build and install all the dependencies. Run the following from MyChiselProject/
-```cd dsp-framework && . ./update.sh```
+
+```
+cd dsp-framework && . ./update.sh
+```
+
 It should build and install the needed dependencies without error, and then run `sbt test` on the dsp-tools project.
 Some of the tests may fail- as of current writing, don't be surprised if you see PFBSpec, BaseNSpec, or ParameterizedSaturatingAdderSpec fail.
 If you see BlackBoxFloatSpec fail, you probably do not have verilator installed and should [follow instructions here](https://github.com/ucb-bar/chisel3) under the 'Install Verilator' heading.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The `--recursive`` option makes sure to check out all the submodules needed for 
 The next step is to build and install all the dependencies. Run the following from MyChiselProject/
 
 ```
-cd dsp-framework && . ./update.sh
+cd dsp-framework && . ./update.bash
 ```
 
 It should build and install the needed dependencies without error, and then run `sbt test` on the dsp-tools project.

--- a/README.md
+++ b/README.md
@@ -12,9 +12,18 @@ The first thing you want to do is clone this repo into a directory of your own. 
 mkdir ~/DspProjects
 cd ~/DspProjects
 
-git clone https://github.com/ucb-art/dsp-template.git MyChiselProject
+git clone --recursive -j8 https://github.com/ucb-art/dsp-template.git MyChiselProject
 cd MyChiselProject
 ```
+
+The `--recursive`` option makes sure to check out all the submodules needed for this project.
+
+The next step is to build and install all the dependencies. Run the following from MyChiselProject/
+```cd dsp-framework && . ./update.sh```
+It should build and install the needed dependencies without error, and then run `sbt test` on the dsp-tools project.
+Some of the tests may fail- as of current writing, don't be surprised if you see PFBSpec, BaseNSpec, or ParameterizedSaturatingAdderSpec fail.
+If you see BlackBoxFloatSpec fail, you probably do not have verilator installed and should [follow instructions here](https://github.com/ucb-bar/chisel3) under the 'Install Verilator' heading.
+
 ### Make your project into a fresh git repo
 There may be more elegant way to do it, but the following works for me. **Note:** this project comes with a magnificent 339 line (at this writing) .gitignore file.
  You may want to edit that first in case we missed something, whack away at it, or start it from scratch.


### PR DESCRIPTION
The update script that calls `git submodule update` is itself inside a submodule. Either the script needs to be moved into this repo, or we need to give instructions on where to run `git submodule update --recursive --init`. One simple solution is to have them clone the repo with --recursive, i.e. `git clone --recursive -j8 git@github.com:ucb-art/dsp-template.git`.

Also, the README doesn't tell them to run update, so I added a line telling them to do that.
