### PR TITLE
Cleaned up GCD example to chisel3 current standard practices

### DIFF
--- a/src/main/scala/example/GCD.scala
+++ b/src/main/scala/example/GCD.scala
@@ -2,28 +2,27 @@
 
 package example
 
-import Chisel._
+import chisel3._
 
 class GCD extends Module {
-  val io = new Bundle {
-    val a  = UInt(INPUT,  16)
-    val b  = UInt(INPUT,  16)
-    val e  = Bool(INPUT)
-    val z  = UInt(OUTPUT, 16)
-    val v  = Bool(OUTPUT)
-  }
+  val io = IO(new Bundle {
+    val a  = Input(UInt(width = 16))
+    val b  = Input(UInt(width = 16))
+    val e  = Input(Bool())
+    val z  = Output(UInt(width = 16))
+    val v  = Output(Bool())
+  })
+
   val x  = Reg(UInt())
   val y  = Reg(UInt())
-  when   (x > y) { x := x - y }
-  unless (x > y) { y := y - x }
+
+  when (x > y) { x := x - y }
+    .otherwise { y := y - x }
   when (io.e) { x := io.a; y := io.b }
   io.z := x
   io.v := y === UInt(0)
 }
 
-object test {
-  def main(args: Array[String]): Unit = {
-    val gen = () => new GCD
-    chiselMain.run(args.drop(2), gen)
-  }
+object GCD extends App {
+  Driver.execute(args, () => new GCD)
 }

--- a/src/test/scala/examples/test/GCDUnitTest.scala
+++ b/src/test/scala/examples/test/GCDUnitTest.scala
@@ -3,6 +3,7 @@
 package examples.test
 
 import Chisel.iotesters.{ChiselFlatSpec, Driver, PeekPokeTester}
+import chisel3.iotesters.TesterOptionsManager
 import example.GCD
 
 class GCDUnitTester(c: GCD) extends PeekPokeTester(c) {
@@ -33,15 +34,13 @@ class GCDUnitTester(c: GCD) extends PeekPokeTester(c) {
 
   for(i <- 1 to 10) {
     for (j <- 1 to 10) {
-      val (a, b, z) = (64, 48, 16)
-
-      poke(gcd.io.a, a)
-      poke(gcd.io.b, b)
+      poke(gcd.io.a, i)
+      poke(gcd.io.b, j)
       poke(gcd.io.e, 1)
       step(1)
       poke(gcd.io.e, 0)
 
-      val (expected_gcd, steps) = computeGcd(a, b)
+      val (expected_gcd, steps) = computeGcd(i, j)
 
       step(steps - 1) // -1 is because we step(1) already to toggle the enable
       expect(gcd.io.z, expected_gcd)
@@ -52,10 +51,14 @@ class GCDUnitTester(c: GCD) extends PeekPokeTester(c) {
 
 class GCDTester extends ChiselFlatSpec {
   val backendNames = Array[String]("firrtl", "verilator")
+
   for ( backendName <- backendNames ) {
-    "GCD" should s"calculate proper greatest common denominator (with ${backendName})" in {
-      Driver(() => new GCD, backendName) {
-        c => new GCDUnitTester(c)
+    "GCD" should s"calculate proper greatest common denominator (with $backendName)" in {
+      val optionsManager = new TesterOptionsManager {
+        testerOptions = testerOptions.copy(backendName = backendName)
+      }
+      dsptools.Driver.execute(() => new GCD, optionsManager) { dut =>
+        new GCDUnitTester(dut)
       } should be (true)
     }
   }


### PR DESCRIPTION
Use IO wrapper and it's methods for identifying genders
Use clean minimalist Driver.execute to create verliator output from a GCD main
GCD unit tests were not really testing with different values, now they are

This PR depends on [/ucb-bar/dsptools/ PR#11](/ucb-bar/dsptools/pull/11)